### PR TITLE
`torch.tanh()` was replaced with `torch.relu()`.

### DIFF
--- a/neural_regression/boston_dnn.ipynb
+++ b/neural_regression/boston_dnn.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,17 +43,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
     "class Net(nn.Module):\n",
     "    def __init__(self):\n",
     "        super(Net, self).__init__()\n",
-    "        self.hid1 = nn.Linear(13, 20)  # 13-(20-20-10)-1\n",
-    "        self.hid2 = nn.Linear(20, 20)\n",
-    "        self.hid3 = nn.Linear(20, 10)\n",
-    "        self.oupt = nn.Linear(10, 1)\n",
+    "        self.hid1 = nn.Linear(13, 30)  # 13-(30-30-20)-1\n",
+    "        self.hid2 = nn.Linear(30, 30)\n",
+    "        self.hid3 = nn.Linear(30, 20)\n",
+    "        self.oupt = nn.Linear(20, 1)\n",
     "\n",
     "        nn.init.xavier_uniform_(self.hid1.weight)  # glorot\n",
     "        nn.init.zeros_(self.hid1.bias)\n",
@@ -65,16 +65,16 @@
     "        nn.init.zeros_(self.oupt.bias)\n",
     "\n",
     "    def forward(self, x):\n",
-    "        z = torch.tanh(self.hid1(x))  # or nn.Tanh()\n",
-    "        z = torch.tanh(self.hid2(z))\n",
-    "        z = torch.tanh(self.hid3(z))\n",
+    "        z = torch.relu(self.hid1(x))  # or nn.ReLU()\n",
+    "        z = torch.relu(self.hid2(z))\n",
+    "        z = torch.relu(self.hid3(z))\n",
     "        z = self.oupt(z)  # no activation, aka Identity()\n",
-    "        return z"
+    "        return z\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -87,19 +87,16 @@
       "Creating 13-(20-20-10)-1 DNN regression model\n",
       "\n",
       "Starting training\n",
-      "batch =      0\t batch loss =  3.6017\t accuracy = 0.50%\n",
-      "batch =   4000\t batch loss =  0.0399\t accuracy = 74.75%\n",
-      "batch =   8000\t batch loss =  0.0406\t accuracy = 75.50%\n",
-      "batch =  12000\t batch loss =  0.0298\t accuracy = 77.97%\n",
-      "batch =  16000\t batch loss =  0.0321\t accuracy = 79.21%\n",
-      "batch =  20000\t batch loss =  0.0800\t accuracy = 79.70%\n",
-      "batch =  24000\t batch loss =  0.0859\t accuracy = 83.91%\n",
-      "batch =  28000\t batch loss =  0.0936\t accuracy = 84.16%\n",
-      "batch =  32000\t batch loss =  0.0486\t accuracy = 85.40%\n",
-      "batch =  36000\t batch loss =  0.0092\t accuracy = 82.92%\n",
+      "batch =      0\t batch loss =  3.2356\t accuracy = 0.00%\n",
+      "batch =  20000\t batch loss =  0.0692\t accuracy = 84.65%\n",
+      "batch =  40000\t batch loss =  0.0157\t accuracy = 93.56%\n",
+      "batch =  60000\t batch loss =  0.0110\t accuracy = 94.55%\n",
+      "batch =  80000\t batch loss =  0.0081\t accuracy = 95.05%\n",
+      "\n",
+      "Reached accuracy threshold of 95.0%. Stopping training.\n",
       "Training complete\n",
       "\n",
-      "Accuracy on test data = 79.41%\n",
+      "Accuracy on test data = 83.33%\n",
       "Model saved to ./boston_model.pth\n",
       "\n",
       "Model loaded from ./boston_model.pth\n",
@@ -110,7 +107,7 @@
       "   6.495000   18.400000    5.491700    7.000000  329.000000 \n",
       "  16.100000  383.609985    8.670000 \n",
       "\n",
-      "Predicted median house price = $27563.08\n"
+      "Predicted median house price = $24420.81\n"
      ]
     }
    ],
@@ -162,7 +159,8 @@
     "    optimizer = optim.SGD(net.parameters(), lr=0.01)\n",
     "    n_items = len(train_x)\n",
     "    batches_per_epoch = n_items // bat_size\n",
-    "    max_batches = 1000 * batches_per_epoch\n",
+    "    max_batches = 5000 * batches_per_epoch  # Increase the number of training sessions\n",
+    "    accuracy_threshold = 95.0  # The accuracy threshold is set to 95.0%\n",
     "\n",
     "    print(\"Starting training\")\n",
     "    for b in range(max_batches):\n",
@@ -176,13 +174,16 @@
     "        loss_obj.backward()  # compute gradients\n",
     "        optimizer.step()  # update weights and biases\n",
     "\n",
-    "        if b % (max_batches // 10) == 0:\n",
+    "        if b % (max_batches // 10) == 0 or b == max_batches - 1:\n",
     "            print(f\"batch = {b:6d}\", end=\"\")\n",
     "            print(f\"\\t batch loss = {loss_obj.item():7.4f}\", end=\"\")\n",
     "            net.eval()\n",
     "            acc = accuracy(net, train_x, train_y, 0.15)\n",
     "            net.train()\n",
     "            print(f\"\\t accuracy = {acc:.2f}%\")\n",
+    "            if acc >= accuracy_threshold:\n",
+    "                print(f\"\\nReached accuracy threshold of {accuracy_threshold}%. Stopping training.\")\n",
+    "                break\n",
     "    print(\"Training complete\\n\")\n",
     "\n",
     "    # 4. evaluate model\n",


### PR DESCRIPTION
- Changed `nn.Linear(13, 20)` to `nn.Linear(13, 30)`.
- Changed `torch.tanh()` to `torch.relu()`.
- Added `max_batches` to increase the number of iterations and `accuracy_threshold` (default is `95`) to set a threshold for stopping training.